### PR TITLE
Fix stack corruption when calling pushboolean.

### DIFF
--- a/shared/lua/functions.odin
+++ b/shared/lua/functions.odin
@@ -53,7 +53,7 @@ foreign liblua {
 	newthread :: proc (L: ^State ) -> ^State ---
 	newuserdatauv :: proc (L: ^State, sz: c.ptrdiff_t, nuvalue: c.int) -> rawptr ---
 	next :: proc (L: ^State , idx: c.int) -> c.int ---
-	pushboolean :: proc (L: ^State , b: c.bool ) ---
+	pushboolean :: proc (L: ^State , b: c.int ) ---
 	pushcclosure :: proc (L: ^State , fn: CFunction, n:c.int) ---
 	pushinteger :: proc (L: ^State , n: Integer ) ---
 	pushlightuserdata :: proc (L: ^State , p: rawptr) ---


### PR DESCRIPTION
pushboolean takes an i32(4 bytes) int but the bindings use c.bool which is an alias to Odin's bool that is 1 byte.